### PR TITLE
Fix order item removal flow and add initial products migration

### DIFF
--- a/src/main/java/com/br/burguesaBurguers/controller/OrderController.java
+++ b/src/main/java/com/br/burguesaBurguers/controller/OrderController.java
@@ -5,9 +5,13 @@ import com.br.burguesaBurguers.dto.OrderItemView;
 import com.br.burguesaBurguers.dto.OrderResponseDTO;
 import com.br.burguesaBurguers.model.Order;
 import com.br.burguesaBurguers.service.OrderService;
+import jakarta.validation.Valid;
+import org.aspectj.weaver.ast.Or;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/orders")
@@ -20,25 +24,46 @@ public class OrderController {
     }
 
     @PostMapping
-    public ResponseEntity<OrderResponseDTO> createOrder(@RequestBody CreateOrderDTO dto) {
+    public ResponseEntity<OrderResponseDTO> createOrder(
+            @RequestBody @Valid CreateOrderDTO dto
+    ) {
         Order order = orderService.createOrder(dto);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(toResponse(order));
+    }
 
-        OrderResponseDTO response = new OrderResponseDTO(
+    @GetMapping("/{orderId}")
+    public ResponseEntity<OrderResponseDTO> getOrderById(
+            @PathVariable Long orderId
+    ) {
+        Order order = orderService.getOrderById(orderId);
+        return ResponseEntity.ok(toResponse(order));
+    }
+
+
+    @DeleteMapping("/{orderId}/items/{productId}")
+    public ResponseEntity<OrderResponseDTO> removeItemFromOrder(
+            @PathVariable Long orderId,
+            @PathVariable Long productId
+    ) {
+        Order order = orderService.removeItemFromOrder(orderId, productId);
+        return ResponseEntity.ok(toResponse(order));
+    }
+
+    // Metodo privado para retornar resposta
+    private OrderResponseDTO toResponse(Order order) {
+        return new OrderResponseDTO(
                 order.getId(),
-                order.getItens().stream().map(item ->
-                        new OrderItemView(
+                order.getItens().stream()
+                        .map(item -> new OrderItemView(
                                 item.getProduct().getName(),
                                 item.getQuantity(),
                                 item.getUnitPrice()
-                        )
-                ).toList(),
+                        ))
+                        .toList(),
                 order.getTotalAmount(),
                 order.getOrderDate()
         );
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
-
-    @DeleteMapping
-    public ResponseEntity<OrderResponseDTO> deleteOrder(@RequestBody )
 }

--- a/src/main/java/com/br/burguesaBurguers/dto/CreateOrderDTO.java
+++ b/src/main/java/com/br/burguesaBurguers/dto/CreateOrderDTO.java
@@ -1,8 +1,13 @@
 package com.br.burguesaBurguers.dto;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
-
 public record CreateOrderDTO(
+
+        @NotNull(message = "Lista de itens é obrigatória")
+        @NotEmpty(message = "O pedido deve conter ao menos um item")
         List<ItemOrderDTO> itens
-){}
+
+) {}

--- a/src/main/java/com/br/burguesaBurguers/model/Order.java
+++ b/src/main/java/com/br/burguesaBurguers/model/Order.java
@@ -20,7 +20,7 @@ public class Order {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true )
     private List<ItemOrder> itens;
 
     @Column(name = "total_amount")

--- a/src/main/java/com/br/burguesaBurguers/service/UserService.java
+++ b/src/main/java/com/br/burguesaBurguers/service/UserService.java
@@ -1,7 +1,9 @@
 package com.br.burguesaBurguers.service;
 
+import com.br.burguesaBurguers.dto.ItemOrderDTO;
 import com.br.burguesaBurguers.dto.UserCreateDTO;
 import com.br.burguesaBurguers.dto.UserResponseDTO;
+import com.br.burguesaBurguers.model.Product;
 import com.br.burguesaBurguers.model.User;
 import com.br.burguesaBurguers.repository.UserRepository;
 import jakarta.validation.constraints.Size;

--- a/src/main/resources/db/migration/V3__products.sql
+++ b/src/main/resources/db/migration/V3__products.sql
@@ -1,0 +1,3 @@
+INSERT INTO products (name, descricao, price, type) VALUES
+("X-bacon", "Lanche com bacon", 12.0, "HAMBURGUER"),
+("Coca-Cola", "Refrigerante", 8.0, "BEBIDA" )


### PR DESCRIPTION
### O que foi feito
- Corrigido o fluxo de remoção de itens do pedido no service e controller
- Padronizado o retorno da API usando `OrderResponseDTO`
- Ajustado o mapeamento para garantir remoção correta de itens (`orphanRemoval`)
- Criada migration SQL para inclusão inicial de produtos

### Por que isso é necessário
- Evita inconsistências no banco ao remover itens de um pedido
- Garante comportamento correto do JPA/Hibernate
- Padroniza as respostas da API para consumo pelo front-end
- Inicializa o banco com dados de produto válidos

### Como testar
1. Subir a aplicação com o banco limpo
2. Criar um pedido via `POST /orders`
3. Remover um item via `DELETE /orders/{orderId}/items/{productId}`
4. Validar se o item é removido do banco e o total do pedido é recalculado

Fixes #1 